### PR TITLE
Update azure-dev.yml

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -73,6 +73,7 @@ jobs:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZD_INITIAL_ENVIRONMENT_CONFIG: ${{ secrets.AZD_INITIAL_ENVIRONMENT_CONFIG }}
 
       - name: 🔃 Deploy Application
         run: azd deploy --no-prompt


### PR DESCRIPTION
Referencing secret to re-construct env-config.
This would avoid the prompt for what services to export and use the selection the user picked during `azd init` or `azd pipeline config`